### PR TITLE
Fix registration to allow character selection

### DIFF
--- a/newauth/blueprints/register.py
+++ b/newauth/blueprints/register.py
@@ -80,7 +80,21 @@ class RegisterView(FlaskView):
 
     @route('password', methods=['GET', 'POST'])
     def password(self):
-        character_id = session['character']
+        character_id = request.args.get('character_id', None)
+        
+        if character_id is None and 'character' in session:
+            character_id = session['character']
+        elif character_id:
+            try:
+                character_id = int(character_id)
+                session['character'] = character_id
+            except ValueError:
+                flash('Invalid Character ID, aborting', 'danger')
+                return redirect(url_for('RegisterView:index'))
+        else:
+            flash('Character ID not found, aborting.', 'danger')
+            return redirect(url_for('RegisterView:index'))
+
         key_id = session['key_id']
         vcode = session['vcode']
         api_key = APIKey(key_id=key_id, vcode=vcode)

--- a/newauth/templates/register/characters.html
+++ b/newauth/templates/register/characters.html
@@ -33,9 +33,9 @@
                 {% for character in api_key.characters %}
                     <div class="col-md-4">
                         {% if character.get_status() == CharacterStatus.internal %}
-                            <button class="btn btn-block btn-success">Internal access</button>
+                            <a class="btn btn-block btn-success" href="{{ url_for('RegisterView:password', character_id=character.id) }}">Internal access</a>
                         {% elif character.get_status() == CharacterStatus.ally %}
-                            <button class="btn btn-block btn-info">Ally access</button>
+                            <a class="btn btn-block btn-info" href="{{ url_for('RegisterView:password', character_id=character.id) }}">Ally access</a>
                         {% else %}
                             <button class="btn btn-block btn-info" disabled>Ineligible</button>
                         {% endif %}


### PR DESCRIPTION
Registration doesn't currently allow characters to be select when there are multiple valid characters on an API key. This allows selection.
