### PR TITLE
Fix a bug where you can't send pings to ally scope

### DIFF
--- a/newauth/templates/pings/new.html
+++ b/newauth/templates/pings/new.html
@@ -45,7 +45,7 @@
                                     <input type="checkbox" name="internal"> Internal
                                 </label>
                                 <label>
-                                    <input type="checkbox" name="internal"> Allies
+                                    <input type="checkbox" name="ally"> Allies
                                 </label>
                             </div>
                         </div>


### PR DESCRIPTION
Ally checkbox was named 'internal' preventing the ally scope from being added when creating pings.
