### PR TITLE
Fixes bug where removing a user from a group sometimes doesn't update ldap

### DIFF
--- a/newauth/plugins/sync/ldap/user.py
+++ b/newauth/plugins/sync/ldap/user.py
@@ -183,6 +183,10 @@ class LDAPUser(LDAPDocument):
                     # We can't delete this attribute, let's set it as ''
                     ldif_changes[key] = (MODIFY_REPLACE, [''])
                 else:
-                    ldif_changes[key] = (MODIFY_DELETE, [self._original_ldap_attributes[key]])
+                    if isinstance(self._original_ldap_attributes[key], list):
+                        ldif_changes[key] = (MODIFY_DELETE,
+                                             self._original_ldap_attributes[key])
+                    else:
+                        ldif_changes[key] = (MODIFY_DELETE, [self._original_ldap_attributes[key]])
         return ldif_changes
 


### PR DESCRIPTION
Removing a user from the last group they were a member threw an error and didn't update ldap properly
